### PR TITLE
Fix evaluation of parameters from yate in mr

### DIFF
--- a/menschenrechte/yate/mr.tcl
+++ b/menschenrechte/yate/mr.tcl
@@ -17,7 +17,7 @@ package require ygi
 
 ## parameters -> variables
 array set cfg {sound_prefix "mr/" mr_start 1 mr_end 30}
-array set cfg [::ygi::filter_env [array names cfg]]
+array set cfg [::ygi::filter_env {*}[array names cfg]]
 
 ##
 


### PR DESCRIPTION
The array names list has been evaluated to early, so parameter transfer did not work.